### PR TITLE
Add multi-file download

### DIFF
--- a/action.php
+++ b/action.php
@@ -8,25 +8,25 @@ require_once( "../../php/xmlrpc.php" );
 eval( getPluginConf( 'webseedsource' ) );
 
 class WeebSeedTorrent extends Torrent {
-		protected $pointer = 0;
-	
-		public function __construct($torrent, $dlpath, $webseedurl) 
-		{
-			$torrentdata = get_object_vars($torrent);
-			foreach ($torrentdata as $key => $value){
-				$this->{$key} = $value;
-			}
-			$url = $webseedurl;
-			if ($dlpath != "") {
-				$url = $url . "/" . $dlpath . "/";
-			}
-			$this->{"url-list"} = [$url];
-			$this->{"announce-list"} = [];
-			$this->{"announce"} = null;
-			$this->{"private"} = 1;
-			return;
+	protected $pointer = 0;
+
+	public function __construct($torrent, $dlpath, $webseedurl) 
+	{
+		$torrentdata = get_object_vars($torrent);
+		foreach ($torrentdata as $key => $value){
+			$this->{$key} = $value;
 		}
-	
+		$url = $webseedurl;
+		if ($dlpath != "") {
+			$url = $url . "/" . $dlpath . "/";
+		}
+		$this->{"url-list"} = [$url];
+		$this->{"announce-list"} = [];
+		$this->{"announce"} = null;
+		$this->{"private"} = 1;
+		return;
+	}
+
 	public function getName($default) {
 		if(is_null($this->name)){
 			return $default;
@@ -37,35 +37,74 @@ class WeebSeedTorrent extends Torrent {
 	}
 }
 
+function make_webseed($webseedbase, $webseedurl, $hash) {
+	$torrent = rTorrent::getSource($hash);
+	if ($torrent) {
+		$req = new rXMLRPCRequest();
+		$req->addCommand(new rXMLRPCCommand( "d.get_directory", $hash));
+		$req->run();
+		$basepath = $req->val[0];
+
+		$req = new rXMLRPCRequest();
+		$req->addCommand(new rXMLRPCCommand( "d.get_base_filename", $hash));
+		$req->run();
+		$filename = $req->val[0];
+
+		$basepath = str_replace($webseedbase, "", $basepath);
+		$basepath = trim(str_replace($filename, "", $basepath), "/");
+
+		$newtorrent = new WeebSeedTorrent($torrent, $basepath, $webseedurl);
+
+		toLog("Generating webseed torrent for ".$hash." with url_list:" . implode(",", $newtorrent->{"url-list"}));
+
+		return $newtorrent;
+	} else {
+		return null;
+	}
+}
 
 function serve_file($webseedurl, $webseedbase){
-	if(isset($_REQUEST['result']))
+	if(isset($_REQUEST['result'])) {
 		cachedEcho('noty(theUILang.cantFindTorrent,"error");',"text/html");
-	if(isset($_REQUEST['hash']))
-	{
-		$torrent = rTorrent::getSource($_REQUEST['hash']);
-		if($torrent){
-			$req = new rXMLRPCRequest();
-			$req->addCommand(new rXMLRPCCommand( "d.get_directory", $_REQUEST['hash']));
-			$req->run();
-			$basepath = $req->val[0];
-			$req = new rXMLRPCRequest();
-			$req->addCommand(new rXMLRPCCommand( "d.get_base_filename", $_REQUEST['hash']));
-			$req->run();
-			$filename = $req->val[0];
-			$basepath = str_replace($webseedbase, "", $basepath);
-			$basepath = trim(str_replace($filename, "", $basepath), "/");
-			$newtorrent = new WeebSeedTorrent($torrent, $basepath, $webseedurl);
-			toLog("Generating torrent with url_list:" . implode(",", $newtorrent->{"url-list"}));
-			
-			if (is_null($filename)){
-				$filename = 'webseed_'.$newtorrent->getName($_REQUEST['hash']).'.torrent';
+	}
+	if(!isset($_REQUEST['hash'])) {
+		return null;
+	}
+	$hashes = explode(" ", urldecode($_REQUEST['hash']));
+	if (count($hashes) == 1) {
+		$torrent = make_webseed($webseedbase, $webseedurl, $hashes[0]);
+		if ($torrent) {
+			$torrent->send();
+		}
+	} else {
+		if (!class_exists('ZipArchive')) {
+			cachedEcho('noty("PHP module \'zip\' is not installed.","error");',"text/html");
+		}
+		ignore_user_abort(true);
+		set_time_limit(0);
+		$zippath = getTempFilename('webseedsource','zip');
+		$zip = new ZipArchive;
+		$zip->open($zippath, ZipArchive::CREATE);
+		foreach($hashes as $hash)
+		{
+			$torrent = make_webseed($webseedbase, $webseedurl, $hash);
+			if ($torrent) {
+				$tmppath = getTempFilename($hash);
+				$remove[] = $tmppath;
+				$torrent->save($tmppath);
+				if (!$zip->addFile($tmppath, $hash. "_webseed.torrent")) {
+					toLog("error adding ".$tmppath." to zip");
+				}
 			}
-			if(isset($_SERVER['HTTP_USER_AGENT']) && strstr($_SERVER['HTTP_USER_AGENT'],'MSIE')){
-				$filename = rawurlencode($filename);
-			}
-			if ($newtorrent)
-				$newtorrent->send();
+		}
+		if (!$zip->close()) {
+			toLog("error closing zip at ".$zippath);
+		}
+		if (sendFile($zippath, "application/zip", null, false)) {
+			unlink($zippath);
+		}
+		foreach ($remove as $tmppath) {
+			unlink($tmppath);
 		}
 	}
 }

--- a/action.php
+++ b/action.php
@@ -10,7 +10,7 @@ eval( getPluginConf( 'webseedsource' ) );
 class WeebSeedTorrent extends Torrent {
 	protected $pointer = 0;
 
-	public function __construct($torrent, $dlpath, $webseedurl) 
+	public function __construct($torrent, $dlpath, $webseedurl, $filename) 
 	{
 		$torrentdata = get_object_vars($torrent);
 		foreach ($torrentdata as $key => $value){
@@ -24,6 +24,9 @@ class WeebSeedTorrent extends Torrent {
 		$this->{"announce-list"} = [];
 		$this->{"announce"} = null;
 		$this->{"private"} = 1;
+		if (is_null($this->name)) {
+			$this->name = str_replace(".torrent", "", $filename);
+		}
 		return;
 	}
 
@@ -53,7 +56,7 @@ function make_webseed($webseedbase, $webseedurl, $hash) {
 		$basepath = str_replace($webseedbase, "", $basepath);
 		$basepath = trim(str_replace($filename, "", $basepath), "/");
 
-		$newtorrent = new WeebSeedTorrent($torrent, $basepath, $webseedurl);
+		$newtorrent = new WeebSeedTorrent($torrent, $basepath, $webseedurl, $filename);
 
 		toLog("Generating webseed torrent for ".$hash." with url_list:" . implode(",", $newtorrent->{"url-list"}));
 
@@ -92,7 +95,8 @@ function serve_file($webseedurl, $webseedbase){
 				$tmppath = getTempFilename($hash);
 				$remove[] = $tmppath;
 				$torrent->save($tmppath);
-				if (!$zip->addFile($tmppath, $hash. "_webseed.torrent")) {
+				$fname = $torrent->getName($hash)."_webseed.torrent";
+				if (!$zip->addFile($tmppath, $torrent->getName($hash). "_webseed.torrent")) {
 					toLog("error adding ".$tmppath." to zip");
 				}
 			}

--- a/init.js
+++ b/init.js
@@ -2,9 +2,21 @@ plugin.loadLang();
 
 if(plugin.canChangeMenu())
 {
-	theWebUI.getWebSeedSource = function( id )
+	theWebUI.getWebSeedSource = function()
 	{
-		$("#webseedsrchash").val(id);
+		var sr = this.getTable("trt").rowSel;
+		var hash = '';
+		for( var k in sr )
+		{
+			if( sr[k] && (k.length == 40) )
+			{
+				if( hash )
+					hash += " " + k;
+				else
+					hash = k;
+			}
+		}
+		$("#webseedsrchash").val(hash);
 		$("#getWebSeedSource").submit();
 	}
 
@@ -16,7 +28,7 @@ if(plugin.canChangeMenu())
 		{
 			var el = theContextMenu.get( theUILang.Properties );
 			if( el )
-				theContextMenu.add( el, [theUILang.getWebSeedSource,  (this.getTable("trt").selCount > 1) || (id.length>40) ? null : "theWebUI.getWebSeedSource('" + id + "')"] );
+				theContextMenu.add( el, [theUILang.getWebSeedSource,  "theWebUI.getWebSeedSource()"] );
 		}
 	}
 }


### PR DESCRIPTION
Based on the same kind of logic that source/ plugin uses, allow either
the download of a single webseed torrent if there's only one selected
line, or download a zip with one torrent per selected line otherwise.